### PR TITLE
resolve old merge conflict

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,7 +1,4 @@
 ^.*\.Rproj$
 ^\.Rproj\.user$
-<<<<<<< HEAD
-=======
 ^cran-comments\.md$
->>>>>>> 8621193fb88cd13fba924e0b8b69fe855d48e00f
-^.*\Ideas_Problems.txt
+^Ideas_Problems.txt

--- a/.directory
+++ b/.directory
@@ -1,8 +1,0 @@
-[Dolphin]
-Timestamp=2017,5,21,14,38,22
-Version=3
-ViewMode=1
-VisibleRoles=Details_text,Details_size,Details_date,Details_owner,CustomizedDetails
-
-[Settings]
-HiddenFilesShown=true

--- a/.gitignore
+++ b/.gitignore
@@ -1,10 +1,8 @@
 .Rproj.user
 .Rhistory
 .RData
-<<<<<<< HEAD
-=======
 .Ruserdata
->>>>>>> 8621193fb88cd13fba924e0b8b69fe855d48e00f
+.directory
 src/*.o
 src/*.so
 src/*.dll


### PR DESCRIPTION
.gitignore and .Rbuildignore contained remnants of an old merge conflict. A miswritten regex prevented the package from building. Both now fixed.